### PR TITLE
Add support for non live messages (old gamepigeon versions)

### DIFF
--- a/app/src/main/java/com/example/openbubblesextension/MadridExtension.kt
+++ b/app/src/main/java/com/example/openbubblesextension/MadridExtension.kt
@@ -85,7 +85,23 @@ class MadridExtension(private val context: Context) : IMadridExtension.Stub() {
     }
 
     override fun didTapTemplate(message: MadridMessage?, handle: IMessageViewHandle?) {
-        // no need to handle, we only have live messages
+        if (message == null || handle == null) return
+        val session = getSessionFor(message.session, handle)
+        session.handleNewMessage(message)
+        val game = session.getGame()
+
+        Log.i("Session", message.session.toString())
+        if (game != null ) {
+            val intent = Intent(context, game.gameClass())
+                .apply {
+                    putExtra("SESSION", message.session)
+                }
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+        } else {
+            Log.e("Game","null")
+            return
+        }
     }
 
     override fun getLiveView(


### PR DESCRIPTION
The iphone 5 only supports an older gp version which uses non live messages