### PR TITLE
fix pool scratch detection and win/loss logic + add tests

### DIFF
--- a/app/src/main/java/com/openbubbles/openpigeon/pool/PoolActivity.kt
+++ b/app/src/main/java/com/openbubbles/openpigeon/pool/PoolActivity.kt
@@ -380,20 +380,18 @@ class PoolActivity : AppCompatActivity() {
     var scratch = false
 
     fun tableIsScratch(): Boolean {
-        var scratch = !cueBall.hitBall || cueBall.sunk
-
-        if (cueBall.ballHit != -1) {
-            val ballHit = poolBalls.find { it.number == cueBall.ballHit } ?: return false
-            val stripes = iAmStripes
-            val hasMoreBalls = stripes == null || poolBalls.count { !it.sunk && ((stripes && it.isStripe) || (!stripes && it.isSolid)) } != 0
-            if (ballHit.number == 8 && !hasMoreBalls) {
-                scratch = false
-            } else if (iAmStripes != null && ((!ballHit.isSolid && !iAmStripes!!) || (!ballHit.isStripe && iAmStripes!!))) {
-                // we hit the wrong ball
-                scratch = true
-            }
-        }
-        return scratch
+        val ballHit = if (cueBall.ballHit != -1) poolBalls.find { it.number == cueBall.ballHit } ?: return false else null
+        val stripes = iAmStripes
+        val remainingBalls = if (stripes == null) 0 else poolBalls.count { !it.sunk && ((stripes && it.isStripe) || (!stripes && it.isSolid)) }
+        return isScratch(
+            cueBallHitSomething = cueBall.hitBall,
+            cueBallSunk = cueBall.sunk,
+            ballHitNumber = ballHit?.number,
+            ballHitIsSolid = ballHit?.isSolid ?: false,
+            ballHitIsStripe = ballHit?.isStripe ?: false,
+            iAmStripes = iAmStripes,
+            remainingBalls = remainingBalls
+        )
     }
 
     var didIWin: Boolean? = null
@@ -480,18 +478,13 @@ class PoolActivity : AppCompatActivity() {
             mode = PoolMode.Disabled
 
 
-            var winState: Boolean? = null
             val blackBall = poolBalls.find { it.number == 8 }!!
-            if (blackBall.sunk) {
-                if (iAmStripes == null || poolBalls.count { !it.sunk && ((iAmStripes!! && it.isStripe) || (!iAmStripes!! && it.isSolid)) } != 0
-                    || blackBall.holeX != calledPocket[0].toFloat() || blackBall.holeY != calledPocket[1].toFloat()) {
-                    // I lose, there are more balls to pocket, or the white ball went in too, or I put it in the wrong hole
-                    winState = false
-                } else {
-                    // this person win
-                    winState = true
-                }
-            }
+            val winState = determineWinState(
+                blackBallSunk = blackBall.sunk,
+                cueBallSunk = cueBall.sunk,
+                remainingBalls = poolBalls.count { !it.sunk && iAmStripes?.let { s -> if (s) it.isStripe else it.isSolid } == true },
+                blackBallInCalledPocket = blackBall.holeX == calledPocket[0].toFloat() && blackBall.holeY == calledPocket[1].toFloat()
+            )
 
             if (poolBalls.any { it.sunk } && !scratch && winState == null) {
                 if (iAmStripes == null && !wasFirst) {

--- a/app/src/main/java/com/openbubbles/openpigeon/pool/PoolRules.kt
+++ b/app/src/main/java/com/openbubbles/openpigeon/pool/PoolRules.kt
@@ -1,0 +1,29 @@
+package com.openbubbles.openpigeon.pool
+
+fun isScratch(
+    cueBallHitSomething: Boolean,
+    cueBallSunk: Boolean,
+    ballHitNumber: Int?,
+    ballHitIsSolid: Boolean,
+    ballHitIsStripe: Boolean,
+    iAmStripes: Boolean?,
+    remainingBalls: Int
+): Boolean {
+    if (!cueBallHitSomething || cueBallSunk) return true
+    if (ballHitNumber == null) return false
+
+    if (ballHitNumber == 8 && remainingBalls == 0) return false
+
+    val hitOpponentsBall = iAmStripes != null && if (iAmStripes) ballHitIsSolid else ballHitIsStripe
+    return hitOpponentsBall
+}
+
+fun determineWinState(
+    blackBallSunk: Boolean,
+    cueBallSunk: Boolean,
+    remainingBalls: Int,
+    blackBallInCalledPocket: Boolean
+): Boolean? {
+    if (!blackBallSunk) return null
+    return remainingBalls == 0 && blackBallInCalledPocket && !cueBallSunk
+}

--- a/app/src/main/java/com/openbubbles/openpigeon/pool/PoolRules.kt
+++ b/app/src/main/java/com/openbubbles/openpigeon/pool/PoolRules.kt
@@ -1,23 +1,30 @@
 package com.openbubbles.openpigeon.pool
 
+// iAmStripes is null until the first ball is sunk and solids/stripes are assigned
 fun isScratch(
     cueBallHitSomething: Boolean,
     cueBallSunk: Boolean,
-    ballHitNumber: Int?,
+    ballHitNumber: Int?,        // null if cue ball hit nothing
     ballHitIsSolid: Boolean,
     ballHitIsStripe: Boolean,
-    iAmStripes: Boolean?,
+    iAmStripes: Boolean?,       // null = not yet assigned
     remainingBalls: Int
 ): Boolean {
+    // missed entirely or sunk the cue ball — always a scratch
     if (!cueBallHitSomething || cueBallSunk) return true
+
+    // cueBall hit something but we have no ball info — not a scratch
     if (ballHitNumber == null) return false
 
+    // hitting the 8-ball as your final shot is valid, not a scratch
     if (ballHitNumber == 8 && remainingBalls == 0) return false
 
+    // hitting the opponent's ball type is a foul
     val hitOpponentsBall = iAmStripes != null && if (iAmStripes) ballHitIsSolid else ballHitIsStripe
     return hitOpponentsBall
 }
 
+// Returns true = win, false = loss, null = game still in progress
 fun determineWinState(
     blackBallSunk: Boolean,
     cueBallSunk: Boolean,
@@ -25,5 +32,7 @@ fun determineWinState(
     blackBallInCalledPocket: Boolean
 ): Boolean? {
     if (!blackBallSunk) return null
+
+    // win only if: no balls left, 8-ball in the called pocket, and no scratch
     return remainingBalls == 0 && blackBallInCalledPocket && !cueBallSunk
 }

--- a/app/src/test/java/com/openbubbles/openpigeon/PoolRulesTest.kt
+++ b/app/src/test/java/com/openbubbles/openpigeon/PoolRulesTest.kt
@@ -1,0 +1,120 @@
+package com.openbubbles.openpigeon
+
+import com.openbubbles.openpigeon.pool.determineWinState
+import com.openbubbles.openpigeon.pool.isScratch
+import org.junit.Assert.*
+import org.junit.Test
+
+class PoolRulesTest {
+
+    @Test
+    fun `scratch on 8 ball in correct pocket is a loss`() {
+        val result = determineWinState(
+            blackBallSunk = true,
+            cueBallSunk = true,
+            remainingBalls = 0,
+            blackBallInCalledPocket = true
+        )
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `clean 8 ball in correct pocket with no balls remaining is a win`() {
+        val result = determineWinState(
+            blackBallSunk = true,
+            cueBallSunk = false,
+            remainingBalls = 0,
+            blackBallInCalledPocket = true
+        )
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `8 ball in wrong pocket is a loss`() {
+        val result = determineWinState(
+            blackBallSunk = true,
+            cueBallSunk = false,
+            remainingBalls = 0,
+            blackBallInCalledPocket = false
+        )
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `8 ball sunk with remaining balls is a loss`() {
+        val result = determineWinState(
+            blackBallSunk = true,
+            cueBallSunk = false,
+            remainingBalls = 2,
+            blackBallInCalledPocket = true
+        )
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `8 ball not sunk means no winner yet`() {
+        val result = determineWinState(
+            blackBallSunk = false,
+            cueBallSunk = false,
+            remainingBalls = 0,
+            blackBallInCalledPocket = true
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `cue ball sunk while shooting 8 ball with no remaining balls is still a scratch`() {
+        val result = isScratch(
+            cueBallHitSomething = true,
+            cueBallSunk = true,
+            ballHitNumber = 8,
+            ballHitIsSolid = false,
+            ballHitIsStripe = false,
+            iAmStripes = false,
+            remainingBalls = 0
+        )
+        assertTrue(result)
+    }
+
+    @Test
+    fun `hitting 8 ball cleanly with no remaining balls is not a scratch`() {
+        val result = isScratch(
+            cueBallHitSomething = true,
+            cueBallSunk = false,
+            ballHitNumber = 8,
+            ballHitIsSolid = false,
+            ballHitIsStripe = false,
+            iAmStripes = false,
+            remainingBalls = 0
+        )
+        assertFalse(result)
+    }
+
+    @Test
+    fun `not hitting any ball is a scratch`() {
+        val result = isScratch(
+            cueBallHitSomething = false,
+            cueBallSunk = false,
+            ballHitNumber = null,
+            ballHitIsSolid = false,
+            ballHitIsStripe = false,
+            iAmStripes = false,
+            remainingBalls = 2
+        )
+        assertTrue(result)
+    }
+
+    @Test
+    fun `hitting wrong ball type is a scratch`() {
+        val result = isScratch(
+            cueBallHitSomething = true,
+            cueBallSunk = false,
+            ballHitNumber = 1,
+            ballHitIsSolid = true,
+            ballHitIsStripe = false,
+            iAmStripes = true, // player is stripes, hit a solid
+            remainingBalls = 2
+        )
+        assertTrue(result)
+    }
+}


### PR DESCRIPTION
Fix 2 pool scratch on 8-ball bugs

Two bugs affecting the scratch while shooting for the 8-ball:

- Cue ball disappearing: When a player scratched while shooting for the 8-ball (8-ball stays on table), the cue ball would vanish for both players, leaving the opponent unable to take their shot.
- Wrong win state: Scratching while sinking the 8-ball was incorrectly awarding a win instead of a loss.
Pool scratch and win/loss logic has been extracted into PoolRules.kt as pure functions, with tests in PoolRulesTest.kt covering both fixes.