### PR TITLE
Include word dictionary in release assets

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -264,7 +264,7 @@ val prepareGodotReleaseAssets by tasks.registering(Sync::class) {
 
     from(godotProjectDir) {
         include("attributions.html")
-        include("global/gp_wg_en2.txt")
+include("global/gp_wg_*.txt")
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -264,6 +264,7 @@ val prepareGodotReleaseAssets by tasks.registering(Sync::class) {
 
     from(godotProjectDir) {
         include("attributions.html")
+        include("global/gp_wg_en2.txt")
     }
 }
 


### PR DESCRIPTION
## Summary

Include the shared word dictionary in release Godot assets.

## Why

Word Bites and Anagrams load `res://global/gp_wg_en2.txt` at runtime with `FileAccess.open(...)`. Debug builds sync the whole Godot asset tree, but release builds unzip the Godot export pack and then overlay only selected extra files. Because the dictionary is a plain text runtime file, it was omitted from release APKs.

When the file is missing, word validation has an empty dictionary, so Word Bites does not recognize words and the possible-words view is empty. Anagrams uses the same dictionary path and is affected by the same release packaging issue.

---

tested and confirmed the fix on pixel 9
with love from codex :P