### PR TITLE
Fix Linux build: ld.lld cannot find -lC++

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -70,4 +70,4 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         android
         log
         Box2D
-        C++)
+        c++_shared)


### PR DESCRIPTION
## Problem

`:app:assembleDebug` fails on Linux at the native link step:

    ld.lld: error: unable to find library -lC++

`app/src/main/cpp/CMakeLists.txt` links the extension library against `C++`. The NDK sysroot has no `libC++.so` and no `libc++.so`: r28 (what AGP 9.2.1 provisions) and r30 both ship only `libc++_shared.so` and `libc++_static.a`. (Locally the entry has presumably been resolving through a case-insensitive filesystem or an older NDK; on Linux there is nothing `-lC++` can match.)

## Fix

Name the library that actually exists: `c++_shared`. That is also the STL the bundled Godot runtime uses at runtime (`libgodot_android.so` lists `NEEDED libc++_shared.so`, and the Godot AAR packages `libc++_shared.so` for all four ABIs), so the extension reuses the copy already in the APK.

This line has regressed once before: ba6c8f6 removed `C++` in Oct 2025, and d4300c4 reintroduced it with the golf physics CMakeLists. Plain removal also works (the clang driver links the STL itself), so if you would rather restore that spelling I can change the diff.

## Tested

Fedora Linux x86_64, JDK 21, AGP-provisioned NDK 28.2.13676358, Godot 4.7.1:

- Before: link failure above.
- After: `BUILD SUCCESSFUL`, debug APK produced. `llvm-readelf -d libopenbubblesextension.so` shows `NEEDED libc++_shared.so`, present in the APK for arm64-v8a, armeabi-v7a, x86, and x86_64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
